### PR TITLE
Make VNC and httpd services optional for docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Vim
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ Defaults to `cfmeqe/sel_ff_chrome`, but can be any docker image that exposes a s
 server on port 4444 and a VNC server on port 5999 (display :99). The `sel_ff_chrome`
 image also exposes nginx's json-based file browser on port 80.
 
+WEBDRIVER_WHARF_IMAGE_VNC_ENABLED
+---------------------------------
+
+Flag for if the docker image will explose a VNC service
+
+Defaults to True
+
+WEBDRIVER_WHARF_IMAGE_HTTP_ENABLED
+---------------------------------
+
+Flag for if the docker image will explose an HTTP service
+
+Defaults to True
+
 WEBDRIVER_WHARF_POOL_SIZE
 -------------------------
 

--- a/webdriver_wharf/db.py
+++ b/webdriver_wharf/db.py
@@ -10,6 +10,8 @@ from sqlalchemy import create_engine, Column, DateTime, Integer, String
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
+from webdriver_wharf.env import vnc_enabled, http_enabled
+
 logger = logging.getLogger(__name__)
 thread_local = local()
 Base = declarative_base()
@@ -63,11 +65,12 @@ class Container(Base):
 
     @property
     def port_bindings(self):
-        return {
-            80: self.http_port,
-            4444: self.webdriver_port,
-            5999: self.vnc_port,
-        }
+        port_bindings = { 4444: self.webdriver_port }
+        if vnc_enabled:
+            port_bindings[5999] = self.vnc_port
+        if http_enabled:
+            port_bindings[80] = self.http_port
+        return port_bindings
 
     @classmethod
     def from_id(cls, docker_id):

--- a/webdriver_wharf/env.py
+++ b/webdriver_wharf/env.py
@@ -1,0 +1,29 @@
+import os
+
+def str2bool(o):
+    if isinstance(o, basestring):
+        o = o.lower() in ['true', '1']
+    return o
+
+# Name of the docker image to use
+image_name = os.environ.get('WEBDRIVER_WHARF_IMAGE', 'cfmeqe/sel_ff_chrome')
+
+# Set to True if the container runs a VNC service
+vnc_enabled = str2bool(os.environ.get('WEBDRIVER_WHARF_IMAGE_VNC_ENABLED',
+    True))
+
+# Set to True if the container runs an http service
+http_enabled = str2bool(os.environ.get('WEBDRIVER_WHARF_IMAGE_HTTP_ENABLED',
+    True))
+
+# Number of containers to have on "hot standby" for checkout
+pool_size = int(os.environ.get('WEBDRIVER_WHARF_POOL_SIZE', 4))
+
+# Max time for an appliance to be checked out before it's forcibly checked in, in seconds.
+max_checkout_time = int(os.environ.get('WEBDRIVER_WHARF_MAX_CHECKOUT_TIME', 3600))
+
+# Interval to check for updates to the docker image (in seconds)
+pull_interval = int(os.environ.get('WEBDRIVER_WHARF_IMAGE_PULL_INTERVAL', 3600))
+
+# Interval to rebalance the active container pool
+rebalance_interval = int(os.environ.get('WEBDRIVER_WHARF_REBALANCE_INTERVAL', 3600 * 6))


### PR DESCRIPTION
My team does not use the VNC or httpd capabilities of the default docker image, which allows us to use the official [selenium docker images](https://hub.docker.com/r/selenium/standalone-firefox/tags/) that do not include VNC or httpd which make the images lighter weight.

This PR makes VNC and httpd optional by adding two environment variables: `WEBDRIVER_WHARF_IMAGE_VNC_ENABLED` and `WEBDRIVER_WHARF_IMAGE_HTTPD_ENABLED` which both default to `True` resulting in no change in default behavior. If either are set to `False`, then the associated docker ports will not be forwarded.

Lastly, this PR adds a `.travis.yml` file and a couple `make` targets for basic python syntax checking. This can be extended to add unit tests in the future.
