### PR TITLE
Support several clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Number of containers to keep in the active pool, ready for checkout.
 
 Defaults to 4
 
+WEBDRIVER_WHARF_CLIENTS
+-------------------------
+
+A list of remote docker hosts to use, e.g. "['tcp://10.0.0.1:4242', 'tcp://10.0.0.2:4242']"
+Before each operation a host with a minimal number of running containers is picked and
+used as a client
+
+Defaults to local docker (unix://var/run/docker.sock)
+
 WEBDRIVER_WHARF_MAX_CHECKOUT_TIME
 ---------------------------------
 

--- a/webdriver_wharf/app.py
+++ b/webdriver_wharf/app.py
@@ -347,6 +347,7 @@ balance_containers.trigger = lambda: scheduler.modify_job(
 def _wharf_init():
     version = require("webdriver-wharf")[0].version
     logger.info('version %s', version)
+    interactions.connect_to_clients()
     # Before doing anything else, grab the image or explode
     logger.info('Pulling image %s -- this could take a while', image_name)
     interactions.pull(image_name)


### PR DESCRIPTION
Pass urls to WEBDRIVER_WHARF_CLIENTS env var and use a client with a minimal number of containers running as a client for current operation
